### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.my-space-app-frontend
+++ b/Dockerfile.my-space-app-frontend
@@ -1,0 +1,29 @@
+# Use a Node.js base image to build the frontend service
+FROM node:16-alpine as build-stage
+
+# Set the working directory
+WORKDIR /app
+
+# Copy package.json and pnpm-lock.yaml
+COPY package.json pnpm-lock.yaml ./
+
+# Install dependencies
+RUN npm install --global pnpm && pnpm install
+
+# Copy the rest of the source code
+COPY . .
+
+# Build the app
+RUN pnpm run build
+
+# Use a lightweight base image for the production stage
+FROM nginx:stable-alpine as production-stage
+
+# Copy the built assets from the build stage
+COPY --from=build-stage /app/dist /usr/share/nginx/html
+
+# Expose port 3000 for the service
+EXPOSE 3000
+
+# Start Nginx and serve the application
+CMD ["nginx", "-g", "daemon off;"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO svelte-starter-2
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,51 @@
+namespace: svelte-starter-2
+
+my-space-app-frontend:
+  defines: runnable
+  metadata:
+    name: my-space-app-frontend
+    description: Frontend service for the Svelte Starter SPA.
+    icon: https://emojiapi.dev/api/v1/globe_with_meridians.svg
+  containers:
+    my-space-app-frontend:
+      image: env-4922.registry.local/my-space-app-frontend:main-dbxja0
+      build: .
+      dockerfile: Dockerfile.my-space-app-frontend
+  services:
+    http-server:
+      description: Port for serving the frontend application over HTTP.
+      container: my-space-app-frontend
+      port: 3000
+      host-port: 3000
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables:
+    api-endpoint:
+      env: API_ENDPOINT
+      type: string
+      value: http://localhost:3000/api
+      description: API endpoint for the frontend service to connect to.
+    api-secret:
+      env: API_SECRET
+      type: string
+      value: '1234'
+      description: Secret key for the API.
+    vite-api-endpoint:
+      env: VITE_API_ENDPOINT
+      type: string
+      value: http://localhost:3000/api
+      description: >-
+        Environment variable used within the Svelte app to define the API
+        endpoint.
+
+stack:
+  defines: group
+  members:
+    - svelte-starter-2/my-space-app-frontend
+  metadata:
+    name: my-space-app
+    description: >-
+      A Svelte Starter single-page application with Vite, TailwindCSS,
+      Flowbite-Svelte, and Svelte-Spa-Router for rapid development.
+    icon: https://emojiapi.dev/api/v1/globe_with_meridians.svg


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration for My-Space-App Frontend

## Dockerfile Creation and Service Mapping

- I have mapped the services for the `svelte-starter-2` repository, identifying it as a standalone SPA named 'my-space-app' with no backend services included.
- The application uses Vite for development and build processes and is served on the default port 3000.
- I created a new `Dockerfile.my-space-app-frontend` to containerize the frontend service, which includes a multi-stage build process using Node.js and Nginx.

## Monk.io Configuration and Deployment

- Added `monk.yaml` and `MANIFEST` files to the repository to configure the deployment with Monk.io.
- The `Dockerfile.my-space-app-frontend` exposes port 3000, which is used for serving the frontend application over HTTP.
- The configuration for the `my-space-app-frontend` service is complete, with the environment variables and port information provided.

## Instructions for Continuation

- The PR is ready to be merged, and the application will be re-deployed on each subsequent push.
- Ensure that the `vite-api-endpoint` variable is set correctly to the API endpoint that the frontend service will connect to. The current value is set to `http://localhost:3000/api`.

## Summary

The containerization and deployment configuration for the 'my-space-app' frontend service is complete. The Dockerfile and Monk.io configuration files are in place, and the service is ready to be deployed in a complete environment. No further action is required unless adjustments to the API endpoint configuration are needed.